### PR TITLE
Playbook updates and version updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,13 @@
-default: build test
+default: install test
 
-build:
+install:
     # Upgrade pip
 	pip install --upgrade pip
 
     # Install Ansible
 	pip install -r requirements.txt
 
-    # Install the ansible.posix collection for mounting devices
-	ansible-galaxy collection install ansible.posix
-
-    # Install the community.docker collection for managing Docker
-	ansible-galaxy collection install community.docker
-
-test: build
+test: install
     # Install testing packages
 	pip install -r requirements-test.txt
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,1 @@
-ansible-lint
+ansible-lint==6.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==6.3.0
+ansible==7.3.0

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -32,7 +32,7 @@
     group: root
     mode: '0755'
 
-- name: Pull the grafana/grafana:{{ grafana_version }} Docker image
+- name: Pull the Docker image grafana/grafana:{{ grafana_version }}
   community.docker.docker_image:
     name: grafana/grafana:{{ grafana_version }}
     source: pull

--- a/roles/grafana/vars/main.yml
+++ b/roles/grafana/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-grafana_version: 9.1.7
+grafana_version: 9.3.6

--- a/roles/influxdb/tasks/main.yml
+++ b/roles/influxdb/tasks/main.yml
@@ -32,7 +32,7 @@
     group: root
     mode: '0755'
 
-- name: Pull the influxdb:{{ influxdb_version }} Docker image
+- name: Pull the Docker image influxdb:{{ influxdb_version }}
   community.docker.docker_image:
     name: influxdb:{{ influxdb_version }}
     source: pull

--- a/roles/influxdb/vars/main.yml
+++ b/roles/influxdb/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-influxdb_version: 2.4.0
+influxdb_version: 2.6.1

--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -24,7 +24,7 @@
     mode: '0644'
   notify: Restart Telegraf
 
-- name: Pull the telegraf:{{ telegraf_version }} Docker image
+- name: Pull the Docker image telegraf:{{ telegraf_version }}
   community.docker.docker_image:
     name: telegraf:{{ telegraf_version }}
     source: pull

--- a/roles/telegraf/vars/main.yml
+++ b/roles/telegraf/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-telegraf_version: 1.24.2
+telegraf_version: 1.25.1


### PR DESCRIPTION
## Playbook updates

- Removed tasks from `Makefile` that were redundant
- Changed the task `build` to `install` in the `Makefile`
- Upgrade version of `ansible` python package to 7.3.0
- Upgrade version of `ansible-lint` python package to 6.14.3
- Refactored the `community.docker.docker_image` tasks for fix a linting issue

## InfluxDB updates

- Upgraded version to 2.6.1

## Telegraf updates

- Upgraded version to 1.25.1

## Grafana updates

- Upgraded version to 9.3.6
 
